### PR TITLE
coccinelle 1.0.6

### DIFF
--- a/Formula/coccinelle.rb
+++ b/Formula/coccinelle.rb
@@ -1,8 +1,8 @@
 class Coccinelle < Formula
   desc "Program matching and transformation engine for C code"
   homepage "http://coccinelle.lip6.fr/"
-  url "http://coccinelle.lip6.fr/distrib/coccinelle-1.0.4.tgz"
-  sha256 "7f823813a2ea299c0f6c01d8419b83c4dc6617116d32ba99d726443a1c22b06d"
+  url "http://coccinelle.lip6.fr/distrib/coccinelle-1.0.6.tgz"
+  sha256 "8452ed265c209dae99cbb33b67bc7912e72f8bca1e24f33f1a88ba3d7985e909"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
No; it's missing a `test do` block. But that's not new to my change.

-----

This update to the latest version of coccinelle fixes the build on macOS Sierra. 👌